### PR TITLE
fix(error-placement) Fixes regression when error placement is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Embed the Lob Address Elements library immediately before the closing &lt;body&g
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx" 
     data-lob-verify-value="strict"
     data-lob-primary-id="address1"
@@ -115,7 +115,7 @@ Embed the Lob Address Elements library immediately before the closing &lt;body&g
 E-commerce platforms like Shopify use predictable element names making them easy to extend. Paste the following preconfigured script into your top-level Shopify Plus template to add address verification to your checkout form. *Remember to replace `live_pub_xxx` with your Lob public key.*
 
 ```
-<script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.merged.js"
+<script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.merged.js"
   data-lob-key="live_pub_xxx"
   data-lob-verify-value="strict"
   data-lob-primary-value="false"
@@ -128,7 +128,7 @@ E-commerce platforms like Shopify use predictable element names making them easy
   data-lob-err-color="#ffffff"></script>
 
 # Here's another example that places the verification message above the submit/continue button at checkout.
-<script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.merged.js"
+<script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.merged.js"
   data-lob-key="live_pub_xxx"
   data-lob-verify-value="strict"
   data-lob-primary-value="false"
@@ -178,7 +178,7 @@ In-line configuration uses attribute values to configure element colors. Hex, RG
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx" 
     data-lob-verify-value="strict"
     data-lob-primary-id="address1"
@@ -318,7 +318,7 @@ When authoring a custom stylesheet, Lob's default stylesheet should be suppresse
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx"
     data-lob-suggestion-stylesheet="false"
     data-lob-verify-value="strict"
@@ -369,7 +369,7 @@ Verification error messages can be localized and customized. Use the pattern, `d
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.2.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/1.2.1/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx" 
     data-lob-verify-value="strict"
     data-lob-primary-id="address1"
@@ -405,16 +405,21 @@ The minified version of the Address Elements library is available for download f
 
 If you do decide to fork and build your own instance of Address Elements, we have provided build tools for minifying your source. Execute via the CLI 
 
-*NOTE: Replace `1.2.0` with the version number you wish to bind to the minified file name.*
+*NOTE: Replace `1.2.1` with the version number you wish to bind to the minified file name.*
 ```
-npm run build 1.2.0
+npm run build 1.2.1
 ```
 
 ## Releases
 
 [Minified builds](https://github.com/lob/lob-address-elements/tree/master/lib) map to the releases listed below.
 
-### 1.2.0 (CURRENT / LATEST)
+### 1.2.1 (CURRENT / LATEST)
+| Release Notes |
+| :---          |
+| Fixes a regression when no data-lob-verify-message-anchor attribute is provided |
+
+### 1.2.0
 | Release Notes |
 | :---          |
 | Adds ability to place verification error message next to any given component |

--- a/src/lob-address-elements.js
+++ b/src/lob-address-elements.js
@@ -373,7 +373,7 @@
           // Determine where to place error message
           var anchor = config.elements.errorAnchorElement;
 
-          if (anchor) {
+          if (anchor.length) {
             message.insertBefore(anchor);
           } else {
             config.elements.form.prepend(message);


### PR DESCRIPTION
When searching for `data-lob-verify-message-anchor-class` and `data-lob-verify-message-anchor-id`, jQuery returns an object instead of null. We end up trying to insert the error message to an element that doesn't exist.