### PR TITLE
feat(did-you-mean): Prompts user for standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,7 @@ Verification error messages can be localized and customized. Use the pattern, `d
     data-lob-err-missing-unit="Enter a Suite or Unit."
     data-lob-err-unnecessary-unit="Suite or Unit unnecessary."
     data-lob-err-incorrect-unit="Incorrect Unit. Please confirm."
-    data-lob-err-notify="The address has been standardized."
-    data-lob-err-confirm="The address has been standardized. Please confirm and resubmit."
+    data-lob-err-confirm="Did you mean"
     data-lob-err-default="Unknown Error. The address could not be verified."></script>
 </body>
 </html>

--- a/src/lob-address-elements.js
+++ b/src/lob-address-elements.js
@@ -530,24 +530,26 @@
           config.elements.zipMsg.hide();
         }
 
-        String.prototype.format = function() {
-          var a = this;
-          for (var k in arguments) {
-            a = a.replace("{" + k + "}", arguments[k])
+        function format(template, args) {
+          for (var k in args) {
+            template = template.replace("{" + k + "}", args[k])
           }
-          return a;
+          return template;
         }
 
         function createStandardizationMessage(payload) {
           const info = config.messages.confirm;
-          const originalAddress = "{0} {1}, {2}, {3} {4}".format(
+          const originalAddress = format("{0} {1}, {2}, {3} {4}", [
             payload.primary_line,
             payload.secondary_line,
             payload.city,
             payload.state,
             payload.zip_code
+          ]);
+          return format(
+            "<span style=\"cursor: pointer\">{0} Click here to revert to your original address: {1}</span>",
+            [info, originalAddress]
           );
-          return "<span style=\"cursor: pointer\">{0} Click here to revert to your original address: {1}</span>".format(info, originalAddress);
         }
 
         /**


### PR DESCRIPTION
[ATL-2276](https://lobsters.atlassian.net/browse/ATL-2276) AV Elements V2 - "Did you mean?" capability

We now prompt the user to standardize their address input instead doing it by default. This means when `data-lob-verify-value = passthrough` we no longer notify the user of the standardization because it doesn't happen automatically and at that point the form has been submitted.

![dym](https://user-images.githubusercontent.com/5534079/118846630-8a4d7480-b892-11eb-9049-12123488b89e.gif)

![image](https://user-images.githubusercontent.com/5534079/118846601-80c40c80-b892-11eb-9863-9b07f169b8ba.png)
