### PR TITLE
feat(form-detection): Implements strategy 1 and handles errors

### DIFF
--- a/src/form-detection.js
+++ b/src/form-detection.js
@@ -1,3 +1,214 @@
+/**
+ * Returns a jquery element to which to add behavior, locating
+ * the element using one of three methods: id, name, attribute.
+ * @param {string} type - For example: primary, secondary, city
+ * @returns {object}
+ */
+export const findElm = type => {
+  const pid = $('*[data-lob-' + type + '-id]').attr('data-lob-' + type + '-id');
+  if (pid) {
+    return $('#' + pid);
+  } else {
+    const pnm = $('*[data-lob-' + type + '-name]').attr('data-lob-' + type + '-name');
+    const pc = $('*[data-lob-' + type + '-class]').attr('data-lob-' + type + '-class');
+    if (pnm) {
+      return $('*[name=' + pnm + ']');
+    } else if (pc) {
+      return $('.' + pc);
+    } else {
+      return $('*[data-lob-' + type + ']');
+    }
+  }
+};
+
+/**
+ * Returns the configuration value for a given @type
+ * @param {string} type - One of: verify, secondary, primary, verify-message
+ * @returns {object}
+ */
+export const findValue = type => {
+  const target = findElm(type);
+  const target_val = target.length && target.attr('data-lob-' + type);
+  return target_val || $('*[data-lob-' + type + '-value]').attr('data-lob-' + type + '-value');
+};
+
+/**
+ * Returns the form parent for a target element, @type, 
+ * unless the user explicitly identifies the form to use via the
+ * 'verify' label
+ * @param {string} type - For example: primary, secondary, zip, etc
+ * @returns {object}
+ */
+export const findForm = type => {
+  const form = findElm('verify');
+  return form.length ? form : findElm(type).closest('form');
+};
+
+/**
+ * Performs a localized search relative to an address component's label
+ * @param {string} type - For example: primary, secondary, city
+ * @returns {null || object} - a jQuery object
+ */
+const findAddressElementByLabel = type => {
+  // Check if user already provided the form attribute. If so then no search needed.
+  const elementFromID = findElm(type);
+  if (elementFromID.length) {
+    return elementFromID;
+  }
+
+  // jQuery selectors are case sensitive so this function will add all case variations.
+  // We do this instead of overriding jQuery's selection method in case it's being used in other
+  // scripts on the page.
+  const expandLabels = labels =>
+    labels.reduce((acc, label) => [...acc, label, label.toLowerCase(), label.toUpperCase()], []);
+
+  const potentialLabels = {
+    primary: expandLabels(['Primary', 'Address']),
+    secondary: expandLabels(['Address 2', 'Secondary', 'Apartment', 'Suite']),
+    city: expandLabels(['City']),
+    state: expandLabels(['State']),
+    zip: expandLabels(['Zip', 'Postal']),
+  };
+
+  /**
+   * Chain together the query selectors of each label. When searching for the primary line we
+   * clarify two variations of an address form:
+   *    Form A           Form B
+   *    Address 1        Address
+   *    Address 2        Apartment, Suite, Unit, etc.
+   * Matching on "Address" would include the secondary label and raise an error, so we exclude
+   * it in the selector.
+   */
+  const selector = potentialLabels[type].map(currentLabel =>
+    type === 'primary' && currentLabel.toLowerCase() === 'address'
+      ? `:contains('${currentLabel}'):not(:contains('${currentLabel} 2'))`
+      : `:contains('${currentLabel}')`
+  ).join(', ');
+
+
+  const selections = $(selector);
+  if (!selections.length) {
+    return null;
+  }
+
+  // Raise an error on multiple matching labels for the user to resolve 
+  if (selections.filter("label").length > 1) {
+    return selections.filter("label");
+  }
+
+  // Selections are ordered from furthest to closest, so the last element most likely contains
+  // the label text itself
+  const label = $(selections[selections.length - 1]);
+  const inputId = label.attr("for");
+
+  if (inputId) {
+    const inputSelections = $(`#${inputId}`);
+    return inputSelections;
+  }
+
+  const siblingSelections = label.siblings("input");
+  if (siblingSelections.length) {
+    return siblingSelections;
+  }
+
+  const childSelections = label.children("input");
+  if (childSelections.length) {
+    return childSelections;
+  }
+
+  const parentSelections = label.parentsUntil("form", "input");
+  if (parentSelections.length) {
+    return parentSelections;
+  }
+
+  return null;
+};
+
+
+const resolveParsingResults = addressElements => {
+  let parseResultError = ''; 
+
+  const missingElements = Object.keys(addressElements).filter(key => {
+    const searchResult = addressElements[key];
+    return searchResult === null || (searchResult && searchResult.length === 0);
+  });
+
+  const multipleElements = Object.keys(addressElements).filter(key => {
+    const searchResult = addressElements[key];
+    return searchResult && searchResult.length > 1;
+  });
+
+  if (missingElements.length) {
+    const formElementNames = missingElements.length > 1 
+      ? missingElements.slice(0, -1).join(', ') + ', and ' + missingElements.slice(-1)
+      : missingElements[0].toString();
+    const formElementAttributes = missingElements.map(name => `data-lob-${name}-id`).join(', ');
+    const consoleMessage =
+      `[Lob AV Elements Error]:\tMissing form elements\n` +
+      `Could not find inputs for ${formElementNames}.\n` +
+      `Please add the following attributes to the AV elements script: ${formElementAttributes}\n` +
+      `For more information visit: https://www.lob.com/guides#av-elements-troubleshooting`;
+    const htmlMessage =
+      "<p style=\"text-align: left\">" +
+      "[Lob AV Elements Error] Missing form elements<br/>" +
+      `Could not find inputs for ${formElementNames}. ` +
+      `Please add the following attributes to the AV elements script: <strong>${formElementAttributes}</strong>.<br/>` +
+      "For more information visit <a href=\"https://www.lob.com/guides#av-elements-troubleshooting\">https://www.lob.com/guides#av-elements-troubleshooting</a>" +
+      "</p>";
+  
+    console.error(consoleMessage);
+    parseResultError = htmlMessage;
+  }
+  
+  if (multipleElements.length) {
+    const formElementNames = multipleElements.length > 1
+      ? multipleElements.slice(0, -1).join(', ') + ', and ' + multipleElements.slice(-1)
+      : multipleElements[0].toString();
+    const formElementAttributes = multipleElements.map(name => `data-lob-${name}-id`).join(', ');
+    const consoleMessage =
+      `[Lob AV Elements Error]:\tDuplicate form elements\n` +
+      `Multiple form elements were found for ${formElementNames}.\n` +
+      `Please specify them by adding the following attributes to the AV elements script: ${formElementAttributes}\n` +
+      `For more information visit: https://www.lob.com/guides#av-elements-troubleshooting`;
+    const htmlMessage =
+      "<p style=\"text-align: left\">" +
+      "[Lob AV Elements Error] Duplicate form elements<br/>" +
+      `Multiple form elements were found for ${formElementNames}. ` +
+      `Please specify them by adding the following attributes to the AV elements script: <strong>${formElementAttributes}</strong>.<br/>` +
+      "For more information visit <a href=\"https://www.lob.com/guides#av-elements-troubleshooting\">https://www.lob.com/guides#av-elements-troubleshooting</a>" +
+      "</p>";
+  
+    console.error(consoleMessage);
+    parseResultError = parseResultError + htmlMessage;
+  }
+
+  return parseResultError;
+};
+
 export const parseWebPage = () => {
-  console.log('parseWebpage');
+  const errorMessageElements = {
+    errorAnchorElement: findElm('verify-message-anchor'),
+    primaryMsg: findElm('primary-message').hide(),
+    secondaryMsg: findElm('secondary-message').hide(),
+    cityMsg: findElm('city-message').hide(),
+    stateMsg: findElm('state-message').hide(),
+    zipMsg: findElm('zip-message').hide(),
+    countryMsg: findElm('country-message').hide(),
+    message: findElm('verify-message').hide()
+  };
+
+  const addressElements = {
+    primary: findAddressElementByLabel('primary'),
+    secondary: findAddressElementByLabel('secondary'),
+    city: findAddressElementByLabel('city'),
+    state: findAddressElementByLabel('state'),
+    zip: findAddressElementByLabel('zip'),
+  };
+
+  return {
+    ...errorMessageElements,
+    ...addressElements,
+    parseResultError: resolveParsingResults(addressElements),
+    form: findForm('primary'),
+  };
 };


### PR DESCRIPTION
[ATL-2283](https://lobsters.atlassian.net/browse/ATL-2283) AV Elements V2 - Form detection implementation

Implements a form detection algorithm for **domestic** address forms. It works by searching for address inputs with relative to key labels (e.g. "Address", "City", "State", etc.). We notify the user if an input is missing or duplicates are found. We also raise an error if we cannot find the form itself.

<img width="1070" alt="Screen Shot 2021-06-02 at 10 29 26 AM" src="https://user-images.githubusercontent.com/5534079/120508670-8723af80-c38d-11eb-8810-aa0024fa1271.png">


### Error Messages
Duplicate inputs | Missing input | Missing `form`
--|--|--
<img width="875" alt="Screen Shot 2021-06-02 at 10 40 47 AM" src="https://user-images.githubusercontent.com/5534079/120510989-93107100-c38f-11eb-87b5-5e34f7f1931b.png"> | <img width="872" alt="Screen Shot 2021-06-02 at 10 41 47 AM" src="https://user-images.githubusercontent.com/5534079/120511002-94da3480-c38f-11eb-859c-1a6970cc1dd9.png"> | <img width="1306" alt="Screen Shot 2021-06-02 at 10 43 41 AM" src="https://user-images.githubusercontent.com/5534079/120511013-973c8e80-c38f-11eb-91eb-7cd13a8f97ee.png">

_These error messages are also included in the console._