### PR TITLE
feat(form-detection): Adds 2nd strategy and supports international address forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,26 +80,19 @@ Embed the Lob Address Elements library immediately before the closing &lt;body&g
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.js"
-    data-lob-key="live_pub_xxx" 
-    data-lob-verify-value="strict"
-    data-lob-primary-id="address1"
-    data-lob-secondary-id="address2"
-    data-lob-city-id="city"
-    data-lob-state-id="state"
-    data-lob-zip-id="zip"
-    data-lob-primary-message-id="address1_err"></script>
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
+    data-lob-key="live_pub_xxx"></script>
 </body>
 </html>
 ```
 
 | Attribute Name    | Attribute Value(s)   | Description      |
 | :---          |  :---                 |   :---              |
-| data-lob-key          | `<lob key>`           | Include your Lob live public key as the attribute value. It will use the format `live_pub_*` and is available via the [Lob Dashboard](https://dashboard.lob.com/#/settings).        |
-| data-lob-verify-value           | `strict`, `normal`, `relaxed`, `passthrough`, `false`         | Include this attribute to pre-verify the user's address submission with Lob.  Choose `relaxed` as the attribute value, if you wish to allow users to submit an errant form once they have been warned. Their resubmission of an unchanged form will be used to indicate their preference to override and submit. Choose `normal` (the default) to halt any submissions that Lob deems undeliverable, while still allowing all other inconsistencies to be submitted once the user has confirmed their choice. Choose `strict` to halt any submission that does not pass verification, including minor errors like missing or unnecessary units. If you wish to verify an address and then submit regardless of the verification result, choose `passthrough`. This is useful for stateful forms that support repeated submissions. Enter `false` if you plan to use Address elements for autocompletion but **not** for verification. |
-| data-lob-primary-value          | `false`      | This is an optional attribute. Set to `false` to disable address autocompletion and only use address verification.        |
+| data-lob-key          | `<lob key>`           | **Required.** Include your Lob live public key as the attribute value. It will use the format `live_pub_*` and is available via the [Lob Dashboard](https://dashboard.lob.com/#/settings).        |
+| data-lob-verify-value           | `strict`, `normal`, `relaxed`, `passthrough`, `false`         | Include this attribute to pre-verify the user's address submission with Lob.  Choose `relaxed` (the default) as the attribute value, if you wish to allow users to submit an errant form once they have been warned. Their resubmission of an unchanged form will be used to indicate their preference to override and submit. Choose `normal` to halt any submissions that Lob deems undeliverable, while still allowing all other inconsistencies to be submitted once the user has confirmed their choice. Choose `strict` to halt any submission that does not pass verification, including minor errors like missing or unnecessary units. If you wish to verify an address and then submit regardless of the verification result, choose `passthrough`. This is useful for stateful forms that support repeated submissions. Enter `false` if you plan to use Address elements for autocompletion but **not** for verification. |
+| data-lob-primary-value          | `false`      | Set to `false` to disable address autocompletion and only use address verification.        |
 | data-lob-primary-id          | `<field id>`      | This attribute identifies the primary address field. Set it to the ID for the field to target.         |
-| data-lob-secondary-value          | `false`      | This is an optional attribute. Set to `false` to force the suite or unit number to render on the primary address line during address verification.         |
+| data-lob-secondary-value          | `false`      | Set to `false` to force the suite or unit number to render on the primary address line during address verification.         |
 | data-lob-secondary-id          | `<field id>`      | This attribute identifies the secondary address field. Set it to the ID for the field to target.         |
 | data-lob-city-id          | `<field id>`      | This attribute identifies the city field. Set it to the ID for the field to target.         |
 | data-lob-state-id          | `<field id>`      | This attribute identifies the state field. Set it to the ID for the field to target.         |
@@ -118,36 +111,29 @@ Embed the Lob Address Elements library immediately before the closing &lt;body&g
 E-commerce platforms like Shopify use predictable element names making them easy to extend. Paste the following preconfigured script into your top-level Shopify Plus template to add address verification to your checkout form. *Remember to replace `live_pub_xxx` with your Lob public key.*
 
 ```
-<script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.merged.js"
+<script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.merged.js"
   data-lob-key="live_pub_xxx"
   data-lob-verify-value="strict"
   data-lob-primary-value="false"
-  data-lob-primary-id="checkout_shipping_address_address1"
-  data-lob-secondary-id="checkout_shipping_address_address2"
-  data-lob-city-id="checkout_shipping_address_city"
-  data-lob-state-id="checkout_shipping_address_province"
-  data-lob-zip-id="checkout_shipping_address_zip"
   data-lob-err-bgcolor="#006eff"
   data-lob-err-color="#ffffff"></script>
 
 # Here's another example that places the verification message above the submit/continue button at checkout.
-<script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.merged.js"
+<script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.merged.js"
   data-lob-key="live_pub_xxx"
   data-lob-verify-value="strict"
   data-lob-primary-value="false"
-  data-lob-primary-id="checkout_shipping_address_address1"
-  data-lob-secondary-id="checkout_shipping_address_address2"
-  data-lob-city-id="checkout_shipping_address_city"
-  data-lob-state-id="checkout_shipping_address_province"
-  data-lob-zip-id="checkout_shipping_address_zip"
   data-lob-err-bgcolor="#006eff"
   data-lob-err-color="#ffffff"
   data-lob-verify-message-anchor-class="step__footer"></script>
 ```
 *NOTE: Many E-commerce platforms have strict content security policies that prevent scripts from loading additional content. Embed the `merged` build of Address Elements to handle these situations as shown in the example above (lob-address-elements.min.merged.js). This ensures all dependencies are included in the download.*
 
+## Form Detection
+With v2.0.0, users no longer have to provide the IDs of their address form inputs in the AV elements script tag. We now detect these inputs on start up by search for inputs and labels with address-related key words. Any errors that may arise are displayed in the web page and the browser's console. The quickest solution is to provide the ID of the problem input back in the AV elements script tag.
+
 ## Component Styles
-When *address verification* is enabled, Lob will inject an HTML element into the target form in order to communicate form-level error messages. Similarly, when *address autocompletion* is enabled, Lob will inject an HTML element to contain suggested addresses. 
+When *address verification* is enabled, Lob will inject an HTML element into the target form in order to communicate form-level error messages. Similarly, when *address autocompletion* is enabled, Lob will inject an HTML element to contain suggested addresses.
 
 In general, it's easy to customize colors and backgrounds for these elements using in-line color declarations. If, however, you require more advanced customization, you must include a custom CSS stylesheet. These options are described in the following two sections. 
 
@@ -181,14 +167,9 @@ In-line configuration uses attribute values to configure element colors. Hex, RG
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx" 
     data-lob-verify-value="strict"
-    data-lob-primary-id="address1"
-    data-lob-secondary-id="address2"
-    data-lob-city-id="city"
-    data-lob-state-id="state"
-    data-lob-zip-id="zip"
     data-lob-suggestion-color="#666666"
     data-lob-suggestion-bgcolor="#fefefe" 
     data-lob-suggestion-bordercolor="#a8a8a8"
@@ -321,7 +302,7 @@ When authoring a custom stylesheet, Lob's default stylesheet should be suppresse
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx"
     data-lob-suggestion-stylesheet="false"
     data-lob-verify-value="strict"
@@ -343,7 +324,7 @@ When authoring a custom stylesheet, Lob's default stylesheet should be suppresse
 Address Elements continually monitors changes to the HTML DOM, looking for address-related fields to enrich. This behavior is available in all evergreen browsers and IE11+.
 
 # International Verification
-Address Elements is capable of verifying international addresses. Simply add the attribute `data-lob-country-id` to enable this feature. When the value of the corresponding country input is outside of the United States, we will automatically use Lob's <a href="https://docs.lob.com/#intl_verifications">international verification endpoint</a>. The same form attributes are used for international verifications despite potentially having different labels than U.S. address forms (e.g. `data-lob-zip-id` is still used for postal code, `data-lob-state-id` for province, etc).
+Address Elements is capable of verifying international addresses. Simply include a country input in your form to enable this feature. When the value of the input is outside the United States we automatically switch to Lob's <a href="https://docs.lob.com/#intl_verifications">international verification endpoint</a>. The same form attributes are used for international verifications despite potentially having different labels than U.S. address forms (e.g. `data-lob-zip-id` is still used for postal code, `data-lob-state-id` for province, etc).
 
 _Note: Autocomplete functionality is disabled for international addresses._
 
@@ -377,14 +358,9 @@ Verification error messages can be localized and customized. Use the pattern, `d
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.3.0/lob-address-elements.min.js"
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx" 
     data-lob-verify-value="strict"
-    data-lob-primary-id="address1"
-    data-lob-secondary-id="address2"
-    data-lob-city-id="city"
-    data-lob-state-id="state"
-    data-lob-zip-id="zip"
     data-lob-err-primary-line="Enter the Primary address."
     data-lob-err-city-state-zip="Enter City and State (or Zip)."
     data-lob-err-zip="Enter a valid Zip."
@@ -424,6 +400,7 @@ npm run build
 ### 2.0.0-beta (Not Released)
 | Current Improvements |
 | :---          |
+| Implements form detection strategies to simplify script usage |
 | Adds support for international verifications |
 | Modularizes our main script with webpack as our bundler |
 

--- a/examples/bootstrap_default_styles.html
+++ b/examples/bootstrap_default_styles.html
@@ -46,16 +46,11 @@
       <input type="submit" value="Submit" class="btn btn-primary">
     </form>
   </div>
-  <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js" 
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js" 
     data-lob-key="live_pub_xxx"
     data-lob-verify-message-id="custom_verify_message"
-    data-lob-verify-value="normal" 
-    data-lob-primary-id="street1"
+    data-lob-verify-value="normal"
     data-lob-primary-message-id="street1_err"
-    data-lob-secondary-id="street2" 
-    data-lob-city-id="city"
-    data-lob-state-id="state" 
-    data-lob-zip-id="zip"
     data-lob-zip-message-id="zip_err"></script>
 </body>
 </html>

--- a/examples/jquery_default_styles.html
+++ b/examples/jquery_default_styles.html
@@ -59,15 +59,10 @@
           });
       });
   </script>
-  <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js" 
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js" 
     data-lob-key="live_pub_xxx"
-    data-lob-verify-value="normal" 
-    data-lob-primary-id="street1"
+    data-lob-verify-value="normal"
     data-lob-primary-message-id="street1_err" 
-    data-lob-secondary-id="street2" 
-    data-lob-city-id="city"
-    data-lob-state-id="state" 
-    data-lob-zip-id="zip" 
     data-lob-zip-message-id="zip_err"></script>
 </body>
 </html>

--- a/examples/jquery_stateful.html
+++ b/examples/jquery_stateful.html
@@ -44,15 +44,10 @@
           });
       });
   </script>
-  <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js" 
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js" 
     data-lob-key="live_pub_xxx"
     data-lob-verify-value="passthrough" 
-    data-lob-primary-id="street1" 
     data-lob-primary-message-id="street1_err"
-    data-lob-secondary-id="street2" 
-    data-lob-city-id="city" 
-    data-lob-state-id="state" 
-    data-lob-zip-id="zip"
     data-lob-zip-message-id="zip_err"></script>    
   </body>
 </html>

--- a/examples/shopify_integration.html
+++ b/examples/shopify_integration.html
@@ -68,15 +68,10 @@
 
     <!-- Paste the following script in your top-level shopify template 
          Remember to replace `live_pub_xxx` with your Lob public key -->
-    <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js"
+    <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
       data-lob-key="live_pub_xxx"
       data-lob-verify-value="strict" 
       data-lob-primary-value="false" 
-      data-lob-primary-id="checkout_shipping_address_address1"
-      data-lob-secondary-id="checkout_shipping_address_address2" 
-      data-lob-city-id="checkout_shipping_address_city"
-      data-lob-state-id="checkout_shipping_address_province" 
-      data-lob-zip-id="checkout_shipping_address_zip"
       data-lob-err-bgcolor="#006eff" 
       data-lob-err-color="#ffffff"></script>
 </body>

--- a/examples/vanilla_attribute_styles.html
+++ b/examples/vanilla_attribute_styles.html
@@ -81,14 +81,9 @@
     </div>
     <input type="submit" value="Submit" class="btn btn-primary">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js" 
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js" 
     data-lob-key="live_pub_xxx"
     data-lob-verify-value="normal"
-    data-lob-primary-id="street1"
-    data-lob-secondary-id="street2"
-    data-lob-city-id="city"
-    data-lob-state-id="state"
-    data-lob-zip-id="zip"
     data-lob-suggestion-color="#666666"
     data-lob-suggestion-bgcolor="#fefefe" 
     data-lob-suggestion-bordercolor="#a8a8a8"

--- a/examples/vanilla_css_styles.html
+++ b/examples/vanilla_css_styles.html
@@ -103,14 +103,8 @@
     </div>
     <input type="submit" value="Submit">
   </form>
-  <script src="https://cdn.lob.com/lob-address-elements/1.1.0/lob-address-elements.min.js" 
+  <script src="https://cdn.lob.com/lob-address-elements/2.0.0/lob-address-elements.min.js"
     data-lob-key="live_pub_xxx"
-    data-lob-suggestion-stylesheet="false" 
-    data-lob-verify-value="strict" 
-    data-lob-primary-id="address1"
-    data-lob-secondary-id="address2" 
-    data-lob-city-id="city" 
-    data-lob-state-id="state" 
-    data-lob-zip-id="zip"></script>
+  ></script>
 </body>
 </html>

--- a/src/form-detection.js
+++ b/src/form-detection.js
@@ -1,3 +1,5 @@
+import { isInternational } from './international-utils.js';
+
 /**
  * Returns a jquery element to which to add behavior, locating
  * the element using one of three methods: id, name, attribute.
@@ -86,10 +88,10 @@ const findAddressElementByLabel = type => {
     labels.reduce((acc, label) => [...acc, label, capitalize(label), label.toUpperCase()], []);
 
   const potentialLabels = {
-    primary: expandLabels(['primary', 'address']),
-    secondary: expandLabels(['address 2', 'secondary', 'apartment', 'suite']),
-    city: expandLabels(['city']),
-    state: expandLabels(['state']),
+    primary: expandLabels(['primary', 'address', 'street']),
+    secondary: expandLabels(['address 2', 'secondary', 'apartment', 'suite', 'unit', 'apt', 'ste']),
+    city: expandLabels(['city', 'town']),
+    state: expandLabels(['state', 'province', 'county', 'region']),
     zip: expandLabels(['zip', 'postal']),
     country: expandLabels(['country'])
   };
@@ -151,9 +153,16 @@ const findAddressElementByLabel = type => {
 const resolveParsingResults = addressElements => {
   let parseResultError = ''; 
 
+  const international = isInternational(addressElements.country);
+
   const missingElements = Object.keys(addressElements).filter(key => {
     // Omit country input in case form is domestic only
     if (key === 'country') {
+      return false;
+    }
+
+    // Some countries like Germany, state is optional and may not exist in their address forms
+    if (key === 'state' && international) {
       return false;
     }
 

--- a/src/form-detection.js
+++ b/src/form-detection.js
@@ -78,7 +78,7 @@ const expandLabels = labels =>
 
 const addressKeyWords = {
   primary: expandLabels(['primary', 'address', 'street']),
-  secondary: expandLabels(['address 2', 'street 2', 'secondary', 'apartment', 'suite', 'unit', 'apt', 'ste']),
+  secondary: expandLabels(['address 2', 'street 2', 'secondary', 'apartment', 'suite', 'building', 'unit', 'apt', 'ste', 'bldg']),
   city: expandLabels(['city', 'town']),
   state: expandLabels(['state', 'province', 'county', 'region', 'district', 'municipality']),
   zip: expandLabels(['zip', 'postal', 'postcode']),

--- a/src/form-detection.js
+++ b/src/form-detection.js
@@ -62,7 +62,7 @@ export const findForm = type => {
       "Could not find form on page. Please ensure that your address form is enclosed by a form tag.<br/>" +
       "For more information visit <a href=\"https://www.lob.com/guides#av-elements-troubleshooting\">https://www.lob.com/guides#av-elements-troubleshooting</a>" +
       "</p>";
-    console.log(consoleError);
+    console.error(consoleError);
   }
 
   return { form: formElement, error };
@@ -78,7 +78,7 @@ const expandLabels = labels =>
 
 const addressKeyWords = {
   primary: expandLabels(['primary', 'address', 'street']),
-  secondary: expandLabels(['address 2', 'secondary', 'apartment', 'suite', 'unit', 'apt', 'ste']),
+  secondary: expandLabels(['address 2', 'street 2', 'secondary', 'apartment', 'suite', 'unit', 'apt', 'ste']),
   city: expandLabels(['city', 'town']),
   state: expandLabels(['state', 'province', 'county', 'region', 'district', 'municipality']),
   zip: expandLabels(['zip', 'postal', 'postcode']),
@@ -115,7 +115,7 @@ const findAddressElementByLabel = type => {
    */
   let selections = $(selector);
   if (type === 'primary') {
-    selections = selections.filter((idx, e) => !/address\s?2/i.test($(e).text()));
+    selections = selections.filter((idx, e) => !/(address|street)\s?2/i.test($(e).text()));
   }
 
   if (!selections.length) {
@@ -264,7 +264,7 @@ const resolveParsingResults = addressElements => {
 
 // Helper function to confirm presence of an address form
 export const findPrimaryAddressInput = () => {
-  const primary = findAddressElementByLabel('primary');
+  const primary = findAddressElementById('primary') || findAddressElementByLabel('primary') || findAddressElementsByInput('primary');
   const error = resolveParsingResults({ primary });
   return { primary, error };
 };

--- a/src/international-utils.js
+++ b/src/international-utils.js
@@ -1,4 +1,9 @@
-export default {
+export const isInternational = countryElement => {
+  return countryElement && countryElement.length
+    && !['United States', 'United States of America', 'US', 'U.S', 'U.S.', 'USA', 'U.S.A', 'U.S.A'].includes(countryElement.val());
+}
+
+export const countryCodes = {
   'afghanistan': 'AF',
   'aland islands': 'AX',
   'albania': 'AL',

--- a/src/international-utils.js
+++ b/src/international-utils.js
@@ -1,6 +1,8 @@
+const usaVariations = ['united states', 'united states of america', 'us', 'u.s', 'u.s.', 'usa', 'u.s.a', 'u.s.a'];
+
 export const isInternational = countryElement => {
   return countryElement && countryElement.length
-    && !['United States', 'United States of America', 'US', 'U.S', 'U.S.', 'USA', 'U.S.A', 'U.S.A'].includes(countryElement.val());
+    && !usaVariations.includes(countryElement.val().toLowerCase());
 }
 
 export const countryCodes = {

--- a/src/lob-address-elements.js
+++ b/src/lob-address-elements.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { findElm, findForm, findValue, findPrimaryAddressInput, parseWebPage } from './form-detection.js';
-import countryCodes from './country-codes.js';
+import { countryCodes, isInternational } from './international-utils.js';
 
 (function () {
   /**
@@ -149,11 +149,6 @@ import countryCodes from './country-codes.js';
         }
       };
 
-      function isInternational() {
-        return config.elements.country && config.elements.country.length
-          && !['United States', 'United States of America', 'US', 'U.S', 'U.S.', 'USA', 'U.S.A', 'U.S.A'].includes(config.elements.country.val());
-      }
-
       function resolveInlineStyle(config, type, subtype) {
         return findValue(type + '-' + subtype) || config.styles[type + '-' + subtype];
       }
@@ -213,7 +208,7 @@ import countryCodes from './country-codes.js';
          * @param {function} cb - callback
          */
         config.do.autocomplete = function (query, cb) {
-          config.international = isInternational();
+          config.international = isInternational(config.elements.country);
 
           if (config.international) {
             return false;
@@ -584,7 +579,7 @@ import countryCodes from './country-codes.js';
          * @param {function} cb - process the response (submit the form or show an error message)
          */
         config.do.verify = function (cb) {
-          config.international = isInternational();
+          config.international = isInternational(config.elements.country);
           config.submit = config.strictness === 'passthrough';
           config.confirmed = isConfirmation();
 

--- a/src/lob-address-elements.js
+++ b/src/lob-address-elements.js
@@ -52,22 +52,41 @@ import { countryCodes, isInternational } from './international-utils.js';
      * Determine the presence of address-related fields and settings
      */
     function getPageState() {
-      const { primary, error: inputError } = findPrimaryAddressInput();
-      const { form, error: formError } = findForm('primary');
+      try {
+        // Propagate error with our message before something else breaks with a more confusing message
+        const { primary, error: inputError } = findPrimaryAddressInput();
+        if (inputError) {
+          throw new Error(inputError);
+        }
 
-      const strictness = resolveStrictness(cfg.strictness);
-      const create_message = findValue('verify-message') === 'true' || (form.length && !findElm('verify-message').length);
-      const autocomplete = primary.length && findValue('primary') !== 'false';
-      const verify = strictness !== 'false' && form.length && (strictness === 'passthrough' || findElm('verify-message').length || create_message);
+        const { form, error: formError } = findForm('primary');
+        if (formError) {
+          throw new Error(inputError);
+        }
 
-      return {
-        autocomplete: autocomplete,
-        verify: verify,
-        enrich: verify || autocomplete,
-        create_message: create_message,
-        strictness: strictness,
-        error: inputError || formError || ''
-      };
+        const strictness = resolveStrictness(cfg.strictness);
+        const create_message = findValue('verify-message') === 'true' || (form.length && !findElm('verify-message').length);
+        const autocomplete = primary.length && findValue('primary') !== 'false';
+        const verify = strictness !== 'false' && form.length && (strictness === 'passthrough' || findElm('verify-message').length || create_message);
+
+        return {
+          autocomplete: autocomplete,
+          verify: verify,
+          enrich: verify || autocomplete,
+          create_message: create_message,
+          strictness: strictness,
+          error: inputError || formError || ''
+        };
+      } catch (error) {
+        return {
+          autocomplete: false,
+          verify: false,
+          enrich: false,
+          create_message: false,
+          strictness: false,
+          error: error.message
+        };
+      }
     }
 
     /**


### PR DESCRIPTION
[ATL-2372](https://lobsters.atlassian.net/browse/ATL-2372) - AV Elements V2 - Form detection international strategy

This PR expands on the address key words used by our form detection strategy to support international key words (e.g. province, postal code, etc.). We also add a new strategy `findAddressElementsByInput` which analyzes every input on a web page instead of searching through labels - similar to Google's autocomplete approach. 

We also update the README and example files in preparation for our v2 release.
